### PR TITLE
feat!:  Calibration, serialization and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target/
 venv
 **/*/__pycache__
 **/*/*cartesian_tree.cpython-*.so
+
+# VS Code
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,8 @@ version = "0.1.0"
 dependencies = [
  "nalgebra",
  "pyo3",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -45,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +67,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -81,6 +95,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba",
  "typenum",
 ]
@@ -113,6 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -249,12 +265,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ keywords = ["Cartesian", "coordinate-systems", "transform", "poses"]
 categories = ["mathematics", "data-structures"]
 
 [dependencies]
-nalgebra = "0.33.2"
+nalgebra = { version = "0.33.2", features = ["serde-serialize"] }
 pyo3 = { version = "0.25.0", features = ["extension-module"] , optional = true}
 thiserror = "2.0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [features]
 bindings = ["dep:pyo3"]

--- a/python/cartesian_tree/lib.py
+++ b/python/cartesian_tree/lib.py
@@ -126,6 +126,28 @@ class Frame:
             orientation = orientation.to_quaternion()
         self._core_frame.update_transformation(position._binding_structure, orientation._binding_structure)
 
+    def to_json(self) -> str:
+        """Serializes the frame tree to a JSON string.
+
+        Returns:
+            The JSON representation of the tree.
+
+        Raises:
+            ValueError: On serialization failure.
+        """
+        return self._core_frame.to_json()
+
+    def apply_config(self, config_json: str) -> None:
+        """Applies a JSON config to update matching transforms in the tree.
+
+        Args:
+            config_json: The JSON string to apply.
+
+        Raises:
+            ValueError: On deserialization or mismatch errors.
+        """
+        self._core_frame.apply_config(config_json)
+
     def parent(self) -> Frame | None:
         """Returns the parent of the frame.
 

--- a/python/cartesian_tree/lib.py
+++ b/python/cartesian_tree/lib.py
@@ -139,10 +139,9 @@ class Pose:
 
     _core_pose: _core.Pose
 
-    @property
-    def frame_name(self) -> str:
-        """Returns the name of the frame of the pose."""
-        return self._core_pose.frame_name
+    def frame(self) -> Frame:
+        """Returns the frame of the pose."""
+        return Frame._from_rust(self._core_pose.frame())
 
     def transformation(self) -> tuple[Position, Quaternion]:
         """Returns the transformation of the pose to its parent frame.

--- a/python/cartesian_tree/lib.py
+++ b/python/cartesian_tree/lib.py
@@ -109,6 +109,15 @@ class Frame:
             return None
         return Frame._from_rust(binding_parent)
 
+    def root(self) -> Frame:
+        """Returns the root frame of the tree.
+
+        Returns:
+            The root frame of the tree.
+        """
+        binding_root = self._core_frame.root()
+        return Frame._from_rust(binding_root)
+
     def children(self) -> list[Frame]:
         """Returns the children of the frame.
 

--- a/python/cartesian_tree/lib.py
+++ b/python/cartesian_tree/lib.py
@@ -53,6 +53,34 @@ class Frame:
         binding_frame = self._core_frame.add_child(name, position._binding_structure, orientation._binding_structure)
         return Frame._from_rust(binding_frame)
 
+    def calibrate_child(
+        self, name: str, desired_position: Position, desired_orientation: RPY | Quaternion, reference_pose: Pose
+    ) -> Frame:
+        """Adds a child frame such that a reference pose, expressed in the new frame, matches the desired isometry.
+
+        Args:
+            name: The name of the new child frame.
+            desired_position: The desired position of the reference pose in the new frame.
+            desired_orientation: The desired orientation of the reference pose in the new frame.
+            reference_pose: The reference pose for calibration.
+
+        Returns:
+            The newly created child frame.
+
+        Raises:
+            ValueError: If a child with the same name already exists.
+        """
+        if isinstance(desired_orientation, RPY):
+            desired_orientation = desired_orientation.to_quaternion()
+
+        binding_frame = self._core_frame.calibrate_child(
+            name,
+            desired_position._binding_structure,
+            desired_orientation._binding_structure,
+            reference_pose._binding_structure,
+        )
+        return Frame._from_rust(binding_frame)
+
     def add_pose(self, position: Position, orientation: RPY | Quaternion) -> Pose:
         """Adds a pose to the current frame.
 
@@ -186,6 +214,10 @@ class Pose:
         """
         binding_pose = self._core_pose.in_frame(target_frame._binding_structure)
         return Pose._from_rust(binding_pose)
+
+    @property
+    def _binding_structure(self) -> Any:
+        return self._core_pose
 
     @classmethod
     def _from_rust(cls, rust_pose: _core.Pose) -> Pose:

--- a/python/tests/test_lib.py
+++ b/python/tests/test_lib.py
@@ -80,6 +80,11 @@ def test_add_pose_and_update() -> None:
     up_pos, _ = pose.transformation()
     assert up_pos.to_tuple() == pytest.approx((4.0, 5.0, 6.0), abs=1e-5)
 
+    # Access frame
+    frame_of_pose = pose.frame()
+    assert frame_of_pose.name == "base"
+    frame_of_pose.add_child("child_of_pose_frame", pos, quat)
+    assert len(frame_of_pose.children()) == 1
 
 def test_pose_in_frame() -> None:
     base = Frame("base")

--- a/python/tests/test_lib.py
+++ b/python/tests/test_lib.py
@@ -13,6 +13,18 @@ def test_create_root_frame() -> None:
     assert frame.parent() is None
     assert frame.depth == 0
 
+def test_tree_structure() -> None:
+    frame = Frame("root")
+    pos = Position(1.0, 2.0, 3.0)
+    quat = Quaternion(0.0, 0.0, 0.0, 1.0)
+    child = frame.add_child("child", pos, quat)
+    grandchild = child.add_child("grandchild", pos, quat)
+    assert grandchild.depth == 2  # noqa: PLR2004
+    parent = grandchild.parent()
+    assert parent is not None
+    assert parent.name == "child"
+    assert grandchild.root().name == "root"
+
 
 def test_add_child_frame_with_quaternion() -> None:
     root = Frame("base")

--- a/python/tests/test_lib.py
+++ b/python/tests/test_lib.py
@@ -125,3 +125,23 @@ def test_calibrate_frame() -> None:
 
     assert pos.to_tuple() == pytest.approx((2.0, 2.0, 2.0), abs=1e-5)
     assert quat.to_tuple() == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-5)
+
+
+def test_serialization() -> None:
+    root = Frame("root")
+    child1 = root.add_child("child1", Position(1, 0, 0), Quaternion(0, 0, 0, 1))
+    child2 = child1.add_child("child2", Position(0, 1, 0), RPY(0, 0, radians(90)))
+    child2.add_pose(Position(0, 0, 1), Quaternion(0, 0, 0, 1))
+
+    json_str = root.to_json()
+
+    default_root = Frame("root")
+    default_child1 = default_root.add_child("child1", Position(2, 0, 0), Quaternion(0, 0, 0, 1))
+    default_child2 = default_child1.add_child("child2", Position(0, 2, 0), RPY(0, 0, radians(90)))
+
+    default_root.apply_config(json_str)
+
+    position, _ = default_child1.transformation_to_parent()
+    assert position.to_tuple() == pytest.approx((1.0, 0.0, 0.0), abs=1e-5)  # Updated back to '1'
+    position, _ = default_child2.transformation_to_parent()
+    assert position.to_tuple() == pytest.approx((0.0, 1.0, 0.0), abs=1e-5)  # Updated back to '1'

--- a/python/tests/test_lib.py
+++ b/python/tests/test_lib.py
@@ -13,6 +13,7 @@ def test_create_root_frame() -> None:
     assert frame.parent() is None
     assert frame.depth == 0
 
+
 def test_tree_structure() -> None:
     frame = Frame("root")
     pos = Position(1.0, 2.0, 3.0)
@@ -98,6 +99,7 @@ def test_add_pose_and_update() -> None:
     frame_of_pose.add_child("child_of_pose_frame", pos, quat)
     assert len(frame_of_pose.children()) == 1
 
+
 def test_pose_in_frame() -> None:
     base = Frame("base")
     frame_1 = base.add_child("frame1", Position(1, 1, 1), Quaternion(0, 0, 0, 1))
@@ -110,3 +112,16 @@ def test_pose_in_frame() -> None:
 
     assert pos.to_tuple() == pytest.approx((1.0, -3.0, 1.0), abs=1e-5)
     assert quat.to_rpy().to_tuple() == pytest.approx((0.0, 0.0, -radians(90)), abs=1e-5)
+
+
+def test_calibrate_frame() -> None:
+    base = Frame("base")
+    reference_frame = base.add_child("reference", Position(1, 1, 1), Quaternion(0, 0, 0, 1))
+    reference_pose = reference_frame.add_pose(Position(1, 1, 1), Quaternion(0, 0, 0, 1))
+
+    calibrated_frame = base.calibrate_child("calibrated", Position(0, 0, 0), RPY(0, 0, 0), reference_pose)
+
+    pos, quat = calibrated_frame.transformation_to_parent()
+
+    assert pos.to_tuple() == pytest.approx((2.0, 2.0, 2.0), abs=1e-5)
+    assert quat.to_tuple() == pytest.approx((0.0, 0.0, 0.0, 1.0), abs=1e-5)

--- a/src/bindings/frame.rs
+++ b/src/bindings/frame.rs
@@ -79,6 +79,12 @@ impl PyFrame {
         self.rust_frame.depth()
     }
 
+    fn root(&self) -> PyFrame {
+        PyFrame {
+            rust_frame: self.rust_frame.root(),
+        }
+    }
+
     fn parent(&self) -> Option<PyFrame> {
         self.rust_frame
             .parent()

--- a/src/bindings/frame.rs
+++ b/src/bindings/frame.rs
@@ -45,6 +45,25 @@ impl PyFrame {
         })
     }
 
+    #[pyo3(signature = (name, desired_position, desired_quaternion, reference_pose))]
+    fn calibrate_child(
+        &self,
+        name: String,
+        desired_position: PyPosition,
+        desired_quaternion: PyQuaternion,
+        reference_pose: &PyPose,
+    ) -> PyResult<PyFrame> {
+        let new_rust_frame = self.rust_frame.calibrate_child(
+            name,
+            desired_position.position,
+            desired_quaternion.quat,
+            &reference_pose.rust_pose,
+        )?;
+        Ok(PyFrame {
+            rust_frame: new_rust_frame,
+        })
+    }
+
     #[pyo3(signature = (position, quaternion))]
     fn add_pose(&self, position: PyPosition, quaternion: PyQuaternion) -> PyPose {
         let rust_pose = self.rust_frame.add_pose(position.position, quaternion.quat);

--- a/src/bindings/frame.rs
+++ b/src/bindings/frame.rs
@@ -93,6 +93,16 @@ impl PyFrame {
         Ok(())
     }
 
+    fn to_json(&self) -> PyResult<String> {
+        Ok(self.rust_frame.to_json()?)
+    }
+
+    #[pyo3(signature = (json))]
+    fn apply_config(&self, json: String) -> PyResult<()> {
+        self.rust_frame.apply_config(&json)?;
+        Ok(())
+    }
+
     #[getter]
     fn depth(&self) -> usize {
         self.rust_frame.depth()

--- a/src/bindings/frame.rs
+++ b/src/bindings/frame.rs
@@ -26,7 +26,7 @@ impl PyFrame {
     }
 
     #[getter]
-    fn name(&self) -> String {
+    pub(crate) fn name(&self) -> String {
         self.rust_frame.name()
     }
 

--- a/src/bindings/pose.rs
+++ b/src/bindings/pose.rs
@@ -16,9 +16,10 @@ pub struct PyPose {
 
 #[pymethods]
 impl PyPose {
-    #[getter]
-    fn frame_name(&self) -> Option<String> {
-        self.rust_pose.frame_name()
+    fn frame(&self) -> Option<PyFrame> {
+        self.rust_pose
+            .frame()
+            .map(|frame| PyFrame { rust_frame: frame })
     }
 
     fn transformation(&self) -> (PyPosition, PyQuaternion) {
@@ -68,7 +69,9 @@ impl PyPose {
         let quaternion = isometry.rotation.coords;
         format!(
             "'{}', ({:.2}, {:.2}, {:.2})({:.4}, {:.4}, {:.4}, {:.4}))",
-            self.frame_name().unwrap_or_else(|| "Unknown".to_string()),
+            self.frame()
+                .map(|frame| frame.name())
+                .unwrap_or_else(|| "Unknown".to_string()),
             position.x,
             position.y,
             position.z,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,4 +14,8 @@ pub enum CartesianTreeError {
     IsNoAncestor(String, String),
     #[error("Internal error: Weak pointer upgrade failed")]
     WeakUpgradeFailed(),
+    #[error("Serialization/Deserialization error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+    #[error("Tree structure mismatch during config apply: {0}")]
+    Mismatch(String),
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -403,7 +403,7 @@ mod tests {
         let frame = Frame::new_origin("dummy");
         let pose = frame.add_pose(Vector3::new(1.0, 2.0, 3.0), UnitQuaternion::identity());
 
-        assert_eq!(pose.frame_name().as_deref(), Some("dummy"));
+        assert_eq!(pose.frame().unwrap().name(), "dummy");
     }
 
     #[test]

--- a/src/pose.rs
+++ b/src/pose.rs
@@ -37,27 +37,23 @@ impl Pose {
         }
     }
 
-    /// Returns the name of the frame in which this pose is defined.
+    /// Returns the parent frame of this pose.
     ///
     /// # Returns
-    ///
-    /// `Some(String)` if the parent frame is still valid, or `None` if the frame
+    /// `Some(Frame)` if the parent frame is still valid, or `None` if the frame
     /// has been dropped or no longer exists.
     ///
     /// # Example
-    ///
     /// ```
     /// use cartesian_tree::Frame;
     /// use nalgebra::{Vector3, UnitQuaternion};
     ///
     /// let frame = Frame::new_origin("base");
     /// let pose = frame.add_pose(Vector3::new(0.0, 0.0, 0.0), UnitQuaternion::identity());
-    /// assert_eq!(pose.frame_name().as_deref(), Some("base"));
+    /// assert_eq!(pose.frame().unwrap().name(), "base");
     /// ```
-    pub fn frame_name(&self) -> Option<String> {
-        self.parent
-            .upgrade()
-            .map(|frame| frame.borrow().name.clone())
+    pub fn frame(&self) -> Option<Frame> {
+        self.parent.upgrade().map(|data| Frame { data })
     }
 
     /// Returns the transformation from this pose to its parent frame.

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -54,6 +54,15 @@ pub trait Walking: HasParent<Node = Self> + NodeEquality + Clone {
         Some(current)
     }
 
+    /// Finds the root of this node.
+    ///
+    /// # Returns
+    ///
+    /// The root Node.
+    fn root(&self) -> Self {
+        self.walk_up(self.depth()).unwrap_or_else(|| self.clone())
+    }
+
     /// Finds the lowest common ancestor with another Node.
     ///
     /// # Arguments.
@@ -124,6 +133,21 @@ mod tests {
         assert!(grandchild.walk_up(1).unwrap().is_same(&child));
         assert!(grandchild.walk_up(2).unwrap().is_same(&root));
         assert!(grandchild.walk_up(3).is_none());
+    }
+
+    #[test]
+    fn test_root() {
+        let root = Frame::new_origin("root");
+        let child = root
+            .add_child("child", Vector3::zeros(), UnitQuaternion::identity())
+            .unwrap();
+        let grandchild = child
+            .add_child("grandchild", Vector3::zeros(), UnitQuaternion::identity())
+            .unwrap();
+
+        assert!(root.root().is_same(&root));
+        assert!(child.root().is_same(&root));
+        assert!(grandchild.root().is_same(&root));
     }
 
     #[test]


### PR DESCRIPTION
Can be viewed commit by commit (no one ever will look at this pr again)

Breaking Changes:
- Drop the `frame_name` function from the `Pose` and replace it with `frame`. One can
still get the name of the returned frame, but i found myself in situations, where i needed
the frame of poses to add new poses or get the root frame.

Adds three features:
-  Possible to "calibrate" a frame, based on known isometry of a reference pose
- Saving and applying a frame layout
- A root getter for the frames
